### PR TITLE
Previously, calling getMAC would break network access outside of the LAN

### DIFF
--- a/software/picow/app1/lib/wifi.py
+++ b/software/picow/app1/lib/wifi.py
@@ -194,8 +194,12 @@ class WiFi(object):
 
     def getMAC(self):
         """@return The MAC address of the WiFi interface on this device."""
-        ap = network.WLAN(network.AP_IF)
-        ap.active(True)
+        mode = network.STA_IF
+        if self._wifiConfigDict[WiFi.MODE_KEY] == WiFi.MODE_AP:
+            mode = network.AP_IF
+        ap = network.WLAN(mode)
+        if not ap.active():
+            ap.active(True)
         ap_mac = ap.config('mac')
         return "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}".format(ap_mac[0], ap_mac[1], ap_mac[2], ap_mac[3], ap_mac[4], ap_mac[5])
 


### PR DESCRIPTION
In trying to access an ntp host, I determined that the code was always calling network.WLAN(network.AP_IF), even if the unit was set to network.STA_IF. The call to an address outside the LAN would work until this was called and then always fail.
The code now defaults to network.STA_IF but will set it to network.AP_IF if that is the mode in the wifi config.
